### PR TITLE
Replica Hyrri's grants

### DIFF
--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -343,7 +343,7 @@ Zodiac Leather
 League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 +30% chance to Suppress Spell Damage
-+(40–50) to Dexterity
++(40–50) to Intelligence
 (140–220)% increased Evasion Rating
 25% increased Shock Duration on Enemies
 (12–18) to (231–347) Added Lightning Damage with Wand Attacks


### PR DESCRIPTION
Fixes Replica Hyrri's Ire stats

### Description of the problem being solved:
Replica Hyrri's Ire gives Intelligence, not Dexterity. https://www.poewiki.net/wiki/Replica_Hyrri%27s_Ire

### Before screenshot:
![image](https://github.com/zebben/PathOfBuilding/assets/58638172/cab4f81f-c143-429f-b211-46b58c0375da)

### After screenshot:
![image](https://github.com/zebben/PathOfBuilding/assets/58638172/549e14d3-c355-4b0b-bd63-a97eed86cebf)

